### PR TITLE
Fixing select option

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -55,7 +55,15 @@ module.exports = {
     var collection = connections[connectionName].collections[collectionName];
 
     // Shim in required query params and parse any logical operators.
-    options.select = _.keys(collection.definition);
+    options.select = (options.select || [])
+      .map(function(def){
+       return collection._transformer._transformations[def];
+      })
+      .filter(function(def){
+        return !!def;
+      });
+
+    if(!options.select.length) options.select = _.keys(collection.definition);
 
     connections[connectionName]
       .getConnection()


### PR DESCRIPTION
Updating `options.select` to accept and parse values and defaulting to all defined fields